### PR TITLE
Some changes to modernize manual

### DIFF
--- a/code/chapter_0-starting_system/template.pnproj
+++ b/code/chapter_0-starting_system/template.pnproj
@@ -1,1 +1,0 @@
-<Project name="template"><MagicFolder excludeFolders="CVS;.svn" filter="*.h" name="include" path="include\"></MagicFolder><MagicFolder excludeFolders="CVS;.svn" filter="*.c;*.cpp" name="source" path="source\"><File path="main.c"></File></MagicFolder><File path="Makefile"></File></Project>

--- a/code/chapter_5-backgrounds/template.pnproj
+++ b/code/chapter_5-backgrounds/template.pnproj
@@ -1,1 +1,0 @@
-<Project name="template"><MagicFolder excludeFolders="CVS;.svn" filter="*.h" name="include" path="include\"></MagicFolder><MagicFolder excludeFolders="CVS;.svn" filter="*.c;*.cpp" name="source" path="source\"><File path="main.c"></File></MagicFolder><File path="Makefile"></File></Project>

--- a/code/chapter_6-sprites/template.pnproj
+++ b/code/chapter_6-sprites/template.pnproj
@@ -1,1 +1,0 @@
-<Project name="template"><MagicFolder excludeFolders="CVS;.svn" filter="*.h" name="include" path="include\"></MagicFolder><MagicFolder excludeFolders="CVS;.svn" filter="*.c;*.cpp" name="source" path="source\"><File path="main.c"></File></MagicFolder><File path="Makefile"></File></Project>

--- a/code/chapter_7-game/template.pnproj
+++ b/code/chapter_7-game/template.pnproj
@@ -1,1 +1,0 @@
-<Project name="template"><MagicFolder excludeFolders="CVS;.svn" filter="*.h" name="include" path="include\"></MagicFolder><MagicFolder excludeFolders="CVS;.svn" filter="*.c;*.cpp" name="source" path="source\"><File path="main.c"></File></MagicFolder><File path="Makefile"></File></Project>

--- a/code/chapter_8-input/template.pnproj
+++ b/code/chapter_8-input/template.pnproj
@@ -1,1 +1,0 @@
-<Project name="template"><MagicFolder excludeFolders="CVS;.svn" filter="*.h" name="include" path="include\"></MagicFolder><MagicFolder excludeFolders="CVS;.svn" filter="*.c;*.cpp" name="source" path="source\"><File path="main.c"></File></MagicFolder><File path="Makefile"></File></Project>

--- a/code/chapter_9-sounds/template.pnproj
+++ b/code/chapter_9-sounds/template.pnproj
@@ -1,1 +1,0 @@
-<Project name="template"><MagicFolder excludeFolders="CVS;.svn" filter="*.h" name="include" path="include\"></MagicFolder><MagicFolder excludeFolders="CVS;.svn" filter="*.c;*.cpp" name="source" path="source\"><File path="main.c"></File></MagicFolder><File path="Makefile"></File></Project>

--- a/code/template/template.pnproj
+++ b/code/template/template.pnproj
@@ -1,1 +1,0 @@
-<Project name="template"><MagicFolder excludeFolders="CVS;.svn" filter="*.h" name="include" path="include\"></MagicFolder><MagicFolder excludeFolders="CVS;.svn" filter="*.c;*.cpp" name="source" path="source\"><File path="main.c"></File></MagicFolder><File path="Makefile"></File></Project>

--- a/manuscript/SUMMARY.md
+++ b/manuscript/SUMMARY.md
@@ -8,7 +8,6 @@
 # Introduction
 
 - [Politics of the Nintendo DS Homebrew Movement](politics.md)
-- [What is a passthrough device and how do I use one?](passthrough.md)
 - [How do I get programs into my Nintendo DS?](loading.md)
 
 # Creating a Game
@@ -26,5 +25,6 @@
 [Postface](postface.md)
 [Appendix A - VRAM](vram.md)
 [Appendix B - Sprites with Bit Twiddling]()
+[Appendix C - What is a passthrough device and how do I use one?](passthrough.md)
 [Glossary](glossary.md)
 [About the Author](author.md)

--- a/manuscript/backgrounds.md
+++ b/manuscript/backgrounds.md
@@ -89,7 +89,7 @@ transformation matrix, you can rotate, scale, and sheer an affine background,
 among other interesting effects. If you want to learn about the cool effects
 you can do with an affine background and an affine transformation matrix, I
 recommend you look at Cearn's tutorial on affine transformations at
-<http://www.coranac.com/tonc/text/affine.htm>.
+<https://gbadev.net/tonc/affine.html>.
 
 ### Coding with this Manual
 

--- a/manuscript/backgrounds.md
+++ b/manuscript/backgrounds.md
@@ -1,4 +1,4 @@
-# Chapter 5
+# Chapter 4
 ## How do I display a background?
 
 ### Some Background Information

--- a/manuscript/game_mechanics.md
+++ b/manuscript/game_mechanics.md
@@ -1,4 +1,4 @@
-# Chapter 7
+# Chapter 6
 ## Basic Game Mechanics Applied to the Space Shooter Genre
 
 ### The Importance of Object Oriented Programming

--- a/manuscript/input.md
+++ b/manuscript/input.md
@@ -1,4 +1,4 @@
-# Chapter 8
+# Chapter 7
 ## Nintendo DS Input Systems
 
 ### Overview

--- a/manuscript/loading.md
+++ b/manuscript/loading.md
@@ -1,4 +1,4 @@
-# Chapter 3
+# Chapter 2
 ## How do I get programs into my Nintendo DS?
 
 ### The Methods

--- a/manuscript/loading.md
+++ b/manuscript/loading.md
@@ -3,21 +3,28 @@
 
 ### The Methods
 
-There are a few ways of getting your code into the Nintendo DS. The first of
-which is the simple GBA flash cart. These flash carts are generally quite
-expensive, have a low availability, and don’t hold very much memory. They fit
-into the phat Nintendo DS systems perfectly and do not stick out from the
-bottom, except on the Nintendo DS Lite, as other things do. The second way of
-running code is on a removable memory device. These kinds of devices come in
-two flavors: Slot-1 and Slot-2. Slot-2 devices, such as the M3 Adapter, G6
-Flash, NeoFlash, SuperCard, and the GBA Movie Player, generally support both
-Nintendo DS and GBA software. Slot-1 devices, such as the M3 Simply, R4DS, M3
-Real, DS-X, NinjaDS, and the Cyclo DS Evolution, generally only support
-Nintendo DS software. Slot-1 devices also fit into the Nintendo DS perfectly.
-The first four of those Slot-2 devices are produced by supporters of piracy and
-should be avoided. It is recommended to use the GBA Movie Player (GBAMP) if you
-want to use a Slot-2 device. With Slot-1 devices, we don't have too much of a
-choice but to choose the lesser of many evils.
+There are a few ways of getting your code into the Nintendo DS or DSi. The
+preferred method depends on which device you own. You will need a flash cart
+device if you own a Nintendo DS, but you don't need more than a regular SD card
+if you own a Nintendo DSi.
+
+Flash carts are devices that have the shape of a regular DS game, except that
+they contain a microSD slot for you to add your own files. There are plenty of
+slot-1 devices, and all of them work in regular Nintendo DS consoles.
+
+There is also the option of using slot-2 devices, but they are hard to find, and
+a bit awkward to use. Check [Appendix C](passthrough.md) for more information
+about how they work.
+
+If you own a Nintendo DSi it's a bit different. You can use slot-1 devices, but
+only the most modern ones. Nintendo DS consoles don't have very advanced
+protection systems, but Nintendo DSi consoles are much better at detecting
+unauthorized devices. Only a few slot-1 devices are still supported.
+
+However, slot-1 devices aren't needed if you own a Nintendo DSi! There are ways
+to modify your console using software to load unauthorized code from the SD card
+slot of the console. This means that you don't need to buy anything at all!
+There are guides online that teach you how to do this.
 
 ### Which Slot-1 Device should I buy?
 
@@ -43,89 +50,12 @@ supporting that kind of company with our business.
 You can learn more about DLDI and how to use it at the DLDI Wiki website,
 <http://dldi.drunkencoders.com/index.php?title=Main_Page>.
 
-### So, which Slot-1 devices are good?
-
-There are so many Slot-1 devices on the market today. Choosing one of them has
-become very difficult, as the choices are so many. In this manual, I'll discuss
-the devices I'm familiar with, which nifty features they purport, and how they
-compare to one another.
-
-### R4DS
-
-This device is built well. It is the most sturdy of the three. It uses microSD
-cards for storage and supports DLDI. This means that you can run homebrew
-software and use the microSD card's filesystem. With the most recent firmware,
-it can even automatically patch generic DLDI homebrew software with the proper
-DLDI driver for the R4DS on the fly. This means that you don't have to use your
-PC to patch your homebrew software before placing it onto your microSD card.
-The R4DS cannot use microSDHC cards, however. Some people have complained about
-the spring loaded microSD slot, so the makers of R4DS have removed it from
-current models. The R4DS is a great device overall and well supported by the
-Nintendo DS homebrew community, but it does not support running GBA software
-unfortunately.
-
-### M3 Real
-
-This device comes in varying configurations for your various needs. It comes
-with both a Slot-1 device and a Slot-2 device. The Slot-2 device is what
-differs between the three M3 Real configurations. In the first and cheapest
-configuration, the Slot-2 pack is simply a rumble pack. In the second and more
-expensive version, the Slot-2 pack is a dual rumble and RAM pack. This
-configuration will also run GBA homebrew. The flash cart size is kept secret by
-M3, for some reason. Natrium42 was kind enough to inform me that, after doing a
-few tests on the pack, that it is at least 8MB in size, but lacks SRAM. The
-third and most expensive configuration, dubbed the "GBA Expansion Package",
-provides a Slot-2 pack with rumble, SRAM, and 32MB of RAM. <!-- XXX verify this
-information with Natrium42 -->
-
-The M3 Real supports DLDI as well. I'm not sure if it can automatically patch
-homebrew with its own driver on the fly, however. The homebrew software may
-need to be patched on a PC before being transferred to the SD card.
-
-The M3 Real supports microSD and microSDHC cards, unlike the R4DS. So if you
-are in the mood for massive storage, the M3 Real can be your friend.
-
-### Cyclo DS Evolution
-
-This device has very recently come to market, but is already making a big
-impression in the community. The Cyclo DS Evolution has the best looking and
-functioning menu system of the three devices, in my opinion. And if you don't
-like it, the menus are skinnable with a number of skins already available for
-the device. You might be thinking, "Why would I care what my menus look or act
-like?" Well, when you use the device to load your software over and over and
-over again, bad menus really piss you off. When you can't use the touch screen
-to scroll up and down and select items and have to use the keys, but holding
-down the keys doesn't make the menu scroll by and you have to press the up and
-down buttons a lot to get to your software, you get pissed off. And yes, there
-really are menus that are this bad.
-
-Aside from the pleasant menus, the Cyclo DS Evolution supports DLDI. It also
-features on the fly DLDI patching. I dislike having to patch my games on my PC
-before loading them onto my microSD card, so this is a great feature.
-
-My favorite feature of the Cyclo DS Evolution is the "remember what I loaded
-last time and load that same program again" feature. Simply holding down L and
-R at boot will boot the last thing that was booted. This enables me to avoid
-navigating the menu system when I'm debugging a program and running it
-repeatedly for testing.
-
-The Cyclo DS Evolution also has a NoPass mode where it will act as a NoPass to
-boot your GBA flash carts, a GBA Movie Player, or any other Slot-2 device.
-
-As you've probably noticed, as I've written the most about the Cyclo DS
-Evolution, that I like it the best of the three devices. It is competitively
-priced with the others, which is good. While it doesn't support running GBA
-software, it feature rich on the Nintendo DS side of things. I recommend the
-Cyclo DS Evlolution to meet all of your Slot-1 needs and desires.
-
 ### Where do I get one of these Slot-1 devices?</title>
 
 Out of the many places to buy these devices, I've been most happy with
 electrobee. electrobee is run by a trusted member of the homebrew community and
 ships worldwide from good ol' Canada (as opposed to who knows where). Their
-prices are quite often the best, too. When you are ready to purchase a Slot-1
-device, I recommend that you visit
-[electrobee.com](http://electrobee.com/index.php?ref=16).
+prices are quite often the best, too.
 
 ### The Slot-2 Device of Choice
 
@@ -133,7 +63,8 @@ If you decide that GBA software development is important for you, you might
 want to consider getting a NoPass and a Slot-2 device. The NoPass will allow
 you to run Nintendo DS software from your Slot-2 device. The Slot-2 device, on
 its own, will be able to run GBA software. If you only care about Nintendo DS
-software, a Slot-1 device will meet your needs well.
+software, a Slot-1 device will meet your needs well, and you can skip the rest
+of this chapter.
 
 The GBA Movie Player is a wonderful device which can run your software from a
 Compact Flash card. Compact Flash cards are very cheap and in high supply. If

--- a/manuscript/passthrough.md
+++ b/manuscript/passthrough.md
@@ -1,4 +1,4 @@
-# Chapter 2
+# Appendix C
 ## What is a passthrough device and how do I use one?
 
 ### Purpose of the Passthrough
@@ -10,6 +10,11 @@ slot, are encrypted. Since it might be illegal to break that encryption, as it
 is a form of proprietary copy protection, we have to get the Nintendo DS to run
 code from a different place than the NDS card slot. Also, it is much easier to
 bypass the encryption than to try and break it.
+
+This kind of device was popular at the beginning of the scene of the Nintendo
+DS. Nowadays, they have been replaced by devices that are inserted in the DS
+slot of the console. While it is still possible to use passthrough devices, they
+are mostly a relic from the past.
 
 ### How a PassMe Works
 

--- a/manuscript/snippets/sprites/1/main.cpp
+++ b/manuscript/snippets/sprites/1/main.cpp
@@ -167,7 +167,7 @@ void initSprites(OAMTable *oam, SpriteInfo *spriteInfo) {
    *  tiles or palettes.
    *
    *  OFFSET_MULTIPLIER is calculated based on the following formula from
-   *  GBATEK (http://nocash.emubase.de/gbatek.htm#dsvideoobjs):
+   *  GBATEK (https://problemkaputt.de/gbatek.htm#dsvideoobjs):
    *    TileVramAddress = TileNumber * BoundaryValue
    *  Since SPRITE_GFX is a uint16*, the compiler will increment the address
    *  it points to by 2 for each change in 1 of the array index into

--- a/manuscript/sound.md
+++ b/manuscript/sound.md
@@ -1,4 +1,4 @@
-# Chapter 9
+# Chapter 8
 ## What about the sounds?
 
 ### A Sound Theory

--- a/manuscript/sprites.md
+++ b/manuscript/sprites.md
@@ -1,4 +1,4 @@
-# Chapter 6
+# Chapter 5
 ## What is a sprite? How do I use them?
 
 ### Magical Fairies?

--- a/manuscript/sprites.md
+++ b/manuscript/sprites.md
@@ -206,7 +206,7 @@ We have to use a transformation derived from our time spent playing with an
 affine transformation matrix. The sprite's affine transformation matrix is used
 slightly differently from the background affine transformation matrix. If you
 have a background in linear algebra, I'd recommend reading up on this portion
-of the hardware at <http://www.coranac.com/tonc/text/affine.htm>.
+of the hardware at <https://gbadev.net/tonc/affine.html>.
 
 <a name="libnds_affine_sprite"></a>
 

--- a/manuscript/sprites.md
+++ b/manuscript/sprites.md
@@ -387,6 +387,20 @@ When you release a production version of your software, the assertions can be
 removed from your code by the preprocessor. To do this with a GNU compiler,
 like the ones we are using, you simply set `NDEBUG`.
 
+Remember to never use assertions for errors that can realistically happen at
+runtime. For example, it is okay to assert that one define is never bigger than
+a different define because it's all evaluated at compile time. It's impossible
+that this changes after the code has been compiled, so it is impossible that an
+end-user of your program will ever find a problem that you haven't seen during
+testing.
+
+However, you should never check that `malloc()` or `fopen()` return a valid
+pointer with `assert()` because it's not guaranteed that they will always do
+what you want them to do. It's possible that your game runs out of RAM because
+the end-user plays in a different way than you during your tests, or that a file
+can't be found because the SD card of the end-user is faulty! Your code needs to
+be able to handle that kind of failures.
+
 ### Displaying the Sprites
 
 In our main function, we now need to initialize our copy of the OAM, create the

--- a/manuscript/sprites.md
+++ b/manuscript/sprites.md
@@ -305,7 +305,7 @@ We'll be using the same memory alignment (boundary) as the GBA uses for our
 sprites. Tile VRAM addresses must be aligned to 32 bytes. If you feel shorted
 by this, since you can't use all 1024 addressable tiles when using 256 color
 tiles, for instance, then you can look up how to use other alignments at
-<http://nocash.emubase.de/gbatek.htm#dsvideoobjs>. You'll have to set
+<https://problemkaputt.de/gbatek.htm#dsvideoobjs>. You'll have to set
 `REG_DISPCNT` (via `videoSetMode()`) with a value defined in
 `libnds/include/nds/arm9/video.h` akin to `DISPLAY_SPR_1D_SIZE_XXX` (the
 default, and the method the GBA and we use, is `DISPLAY_SPR_1D_SIZE_32`).

--- a/manuscript/toolchains.md
+++ b/manuscript/toolchains.md
@@ -1,4 +1,4 @@
-# Chapter 4
+# Chapter 3
 ## How do I create programs?
 
 ### All About devkitPro


### PR DESCRIPTION
This PR:

- Removes Programmers Notepad project files (this isn't useful nowadays).
- Turns the chapter of Slot-2 devices into an appendix (it's confusing to keep it as a regular chapter, nobody uses this kind of devices anymore).
- It adds some mentions to DSi consoles and how to run homebrew there (this needs more work).
- It improves the explanation of DMA copies and assertions usage.
- It updates some broken links to GBATEK and Tonc.

Check the individual commits when reviewing the changes, it will be easier.